### PR TITLE
Bump svg version to eliminate a clippy warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ documentation = "https://docs.rs/draw"
 
 [dependencies]
 rgb = "0.8.14"
-svg = "0.5.12"
+svg = "0.18"
 rand = {version="0.7.0", features=["small_rng"]}
 cgmath = "0.17.0"


### PR DESCRIPTION
Hey! The following clippy error appears in my project (https://github.com/fadeevab/design-patterns-rust).
```
warning: the following packages contain code that will be rejected by a future version of Rust: svg v0.5.12
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```
 The fix is easy and it works. Just rebase and merge it :)